### PR TITLE
fix duplicate auth headers error

### DIFF
--- a/Q101.NetCoreHttpRequestHelper/Concrete/HttpRequestHelper.cs
+++ b/Q101.NetCoreHttpRequestHelper/Concrete/HttpRequestHelper.cs
@@ -140,8 +140,12 @@ namespace Q101.NetCoreHttpRequestHelper
                 HttpClient.DefaultRequestHeaders.Authorization = _authenticationHeader;
             }
 
-            if (!string.IsNullOrEmpty(_customAuthorizationHeader.Value))
+            if (!string.IsNullOrEmpty(_customAuthorizationHeader.Value)
+                && HttpClient.DefaultRequestHeaders.Authorization == null)
             {
+                HttpClient.DefaultRequestHeaders.Remove(
+                    _customAuthorizationHeader.Key);
+
                 HttpClient.DefaultRequestHeaders.Add(
                     _customAuthorizationHeader.Key,
                     _customAuthorizationHeader.Value);


### PR DESCRIPTION
fixed HttpClient "Cannot add value because header 'Authorization' does not support multiple values" error